### PR TITLE
feat(client): H-1 closeout + 符号链接修复 + Issue #13 标记

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,9 @@ cd UsrLinuxEmu
 
 ## 已知问题
 
-- 插件 teardown 时 SIGSEGV - Issue #13 (UsrLinuxEmu)
-  - 原因: plugin_fini_internal() 未从 VFS 注销设备
-  - 不影响功能，测试完成后 teardown 时触发
+- ~~插件 teardown 时 SIGSEGV~~ - Issue #13 ✅ **已修复** (2026-05-09, commit dd81e5c)
+  - 修复: plugin_fini_internal() 销毁顺序改为 stop puller → reset → unregister device
+  - 验证: 所有测试 (test_gpu_plugin 等) 均正常 teardown，无 SIGSEGV
 
 ## GitHub Issues
 

--- a/UsrLinuxEmu
+++ b/UsrLinuxEmu
@@ -1,1 +1,1 @@
-../UsrLinuxEmu/
+../../

--- a/include/gpu_driver_client.h
+++ b/include/gpu_driver_client.h
@@ -14,6 +14,8 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <cstring>
+#include <cstdio>
 #include <string>
 #include <fcntl.h>
 #include <unistd.h>
@@ -110,6 +112,116 @@ public:
             return -1;
         }
         return 0;
+    }
+
+    // ============================================================
+    // Phase 1.5 便捷方法
+    // ============================================================
+
+    /**
+     * 获取 Warp 大小
+     * @return Warp 大小 (NVIDIA=32, AMD CDNA=64, AMD RDNA=32)
+     */
+    u32 get_warp_size() {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) == 0) return info.warp_size;
+        return 0;
+    }
+
+    /**
+     * 获取 SIMD 单元数量
+     * @return SIMD 数量 (AMD CU 或 NVIDIA SM)
+     */
+    u32 get_simd_count() {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) == 0) return info.simd_count;
+        return 0;
+    }
+
+    /**
+     * 获取峰值 FP32 性能
+     * @return 峰值 FP32 GFLOPS
+     */
+    u32 get_peak_fp32_gflops() {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) == 0) return info.peak_fp32_gflops;
+        return 0;
+    }
+
+    /**
+     * 获取最大引擎时钟频率
+     * @return 最大时钟频率 (MHz)
+     */
+    u32 get_max_clock_frequency() {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) == 0) return info.max_clock_frequency;
+        return 0;
+    }
+
+    /**
+     * 获取驱动版本字符串
+     * @param out 输出缓冲区
+     * @param size 缓冲区大小
+     * @return 0 成功，-1 失败
+     */
+    int get_driver_version_string(char* out, size_t size) {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) != 0) return -1;
+        // 版本格式: 主.次.修订 (0x000500 = v0.5.0)
+        u8 major = (info.driver_version >> 8) & 0xFF;
+        u8 minor = (info.driver_version >> 4) & 0xFF;
+        u8 patch = info.driver_version & 0xFF;
+        snprintf(out, size, "v%u.%u.%u", major, minor, patch);
+        return 0;
+    }
+
+    /**
+     * 获取市场营销名称
+     * @param out 输出缓冲区
+     * @param size 缓冲区大小
+     * @return 0 成功，-1 失败
+     */
+    int get_marketing_name(char* out, size_t size) {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) != 0) return -1;
+        strncpy(out, info.marketing_name, size - 1);
+        out[size - 1] = '\0';
+        return 0;
+    }
+
+    /**
+     * 打印完整设备信息 (调试用)
+     * @param os 输出流
+     */
+    void print_device_info(std::ostream& os = std::cout) {
+        struct gpu_device_info info{};
+        if (get_device_info(&info) != 0) {
+            os << "Failed to get device info\n";
+            return;
+        }
+
+        char version[32];
+        char name[64];
+        get_driver_version_string(version, sizeof(version));
+        get_marketing_name(name, sizeof(name));
+
+        os << "=== GPU Device Info ===\n";
+        os << "  Vendor ID:     0x" << std::hex << info.vendor_id << std::dec << "\n";
+        os << "  Device ID:     0x" << std::hex << info.device_id << std::dec << "\n";
+        os << "  VRAM Size:     " << (info.vram_size / (1024*1024*1024)) << " GB\n";
+        os << "  BAR0 Size:     " << (info.bar0_size / (1024*1024)) << " MB\n";
+        os << "  Compute Units: " << info.compute_units << "\n";
+        os << "  Warp Size:     " << info.warp_size << "\n";
+        os << "  SIMD Count:    " << info.simd_count << "\n";
+        os << "  Driver Ver:    " << version << "\n";
+        os << "  Firmware Ver:   0x" << std::hex << info.firmware_version << std::dec << "\n";
+        os << "  Max Clock:     " << info.max_clock_frequency << " MHz\n";
+        os << "  Mem Clock:     " << info.max_memory_clock_frequency << " MHz\n";
+        os << "  Mem Bus Width: " << info.memory_bus_width << "-bit\n";
+        os << "  Peak FP32:     " << info.peak_fp32_gflops << " GFLOPS\n";
+        os << "  PCIe BW:       " << info.pcie_bandwidth << " Mbps\n";
+        os << "  Architecture:  0x" << std::hex << info.architecture_id << std::dec << "\n";
+        os << "  Marketing:     " << name << "\n";
     }
 
     // ============================================================
@@ -226,7 +338,7 @@ public:
 
         struct gpu_pushbuffer_args args = {};
         args.stream_id = stream_id;
-        args.entries = entries;
+        args.entries_addr = reinterpret_cast<u64>(entries);
         args.count = count;
         args.flags = flags;
         args.fence_id = 0;  // 初始化

--- a/include/gpu_driver_client.h
+++ b/include/gpu_driver_client.h
@@ -342,6 +342,7 @@ public:
         args.count = count;
         args.flags = flags;
         args.fence_id = 0;  // 初始化
+        args.va_space_handle = current_va_space_handle_;  // 透传 VA Space（0 = 跳过 H-1 校验）
 
         if (ioctl(fd_, GPU_IOCTL_PUSHBUFFER_SUBMIT_BATCH, &args) < 0) {
             std::cerr << "GpuDriverClient: GPU_IOCTL_PUSHBUFFER_SUBMIT_BATCH failed"
@@ -465,9 +466,34 @@ public:
         return wait_fence(fence_id, 0, &status);
     }
 
+    // ============================================================
+    // VA Space 透传 (H-1 closeout)
+    // ============================================================
+
+    /**
+     * 设置当前 VA Space handle
+     *
+     * 透传给后续 submit_batch() 调用。设为 0 时，H-1 校验
+     * (validate VA Space exists + validate Queue belongs to VA Space)
+     * 将被跳过（向后兼容 sentinel）。调用方应在创建 VA Space 后立即设置。
+     *
+     * @param va_space_handle VA Space handle (0 = 跳过校验)
+     */
+    void setCurrentVASpace(uint64_t va_space_handle) {
+        current_va_space_handle_ = va_space_handle;
+    }
+
+    /**
+     * 获取当前 VA Space handle
+     */
+    uint64_t getCurrentVASpace() const {
+        return current_va_space_handle_;
+    }
+
 private:
     int fd_;                      // 设备文件描述符
     std::string device_path_;      // 设备路径
+    uint64_t current_va_space_handle_ = 0;  // 默认 0 = 走 H-1 sentinel 跳过校验
 };
 
 /**

--- a/plans/sync-plan.md
+++ b/plans/sync-plan.md
@@ -258,7 +258,7 @@ build/plugins/gpu_driver/
 | S1 | Phase 1 | ✅ 完成 | 2026-04-28 |
 | S2 | Phase 1 | ✅ 完成 | 2026-04-28 |
 | S3 | Phase 1 | ✅ 完成 | 2026-04-28 |
-| S3.5 | Phase 1.5 | ⏳ 待发起 | - |
+| S3.5 | Phase 1.5 | ✅ 已完成 (2026-05-13) | fence_id 返回机制已实现 |
 | S4 | Phase 1 | ⏳ 进行中 | - |
 | S5 | Phase 2 | ⏳ 待发起 | - |
 
@@ -269,7 +269,7 @@ build/plugins/gpu_driver/
 | Phase 0 | 7 | 5 | 2 |
 | Phase 1 (定义) | 6 | 6 | 0 |
 | Phase 1 (实现) | 6 | 6 | 0 |
-| Phase 1.5 | 3 | 2 | 1 |
+| Phase 1.5 | 3 | 3 | 0 |
 | Phase 2 | 5 | 0 | 5 |
 | **总计** | **27** | **19** | **8** |
 

--- a/plans/sync-plan.md
+++ b/plans/sync-plan.md
@@ -151,6 +151,8 @@ UsrLinuxEmu 团队                          TaskRunner 团队
 **Issue**: TaskRunner #4
 **日期**: 2026-04-28
 
+**S3.1 va_space_handle 透传**（2026-06-17, change `h1-pushbuffer-validation-closeout`）：✅ 已加 `setCurrentVASpace()` API（opt-in，默认 0 走 H-1 sentinel 跳过校验）。`GpuDriverClient::submit_batch()` 在 ioctl 前自动透传 `current_va_space_handle_` 到 `args.va_space_handle`。ABI 兼容（旧调用方零行为变化）。
+
 **确认的 GPFIFO Entry 填充**:
 
 **MEMCPY (h2d/d2h)**:

--- a/plans/sync-plan.md
+++ b/plans/sync-plan.md
@@ -114,7 +114,23 @@ UsrLinuxEmu 团队                          TaskRunner 团队
 | gpfifo_capacity | ✅ 需要 | ✅ 1024 |
 | cache_line_size | ⚠️ 可选 | ✅ 64 |
 
-**Phase 1.5 新增字段**: warp_size, max_clock_frequency, driver_version
+**Phase 1.5 已完成字段** (2026-05-13):
+
+| 字段 | 类型 | 值 |
+|------|------|-----|
+| warp_size | u32 | 32 (NVIDIA 风格) |
+| max_clock_frequency | u32 | 1500 MHz |
+| driver_version | u32 | 0x000500 (v0.5.0) |
+| firmware_version | u32 | 0x000100 (v0.1.0) |
+| simd_count | u32 | 64 |
+| max_memory_clock_frequency | u32 | 2000 MHz |
+| memory_bus_width | u32 | 256-bit |
+| peak_fp32_gflops | u32 | 17000 |
+| pcie_bandwidth | u32 | 16000 Mbps |
+| architecture_id | u32 | 0x1001 |
+| marketing_name | char[64] | "UsrLinuxEmu Simulator v1" |
+
+**struct 总大小**: 144 字节
 
 ### 3.3 S2: ALLOC_BO 参数确认 ✅
 
@@ -218,8 +234,9 @@ build/plugins/gpu_driver/
 
 | 任务 | 状态 | 说明 |
 |------|------|------|
-| `gpu_pushbuffer_args` 增加 `fence_id` 字段 | ⏳ 待发起 | S3.5 同步点 |
-| `gpu_device_info` 增加 warp_size 等字段 | ⏳ 待发起 | S1 后续 |
+| `gpu_pushbuffer_args.fence_id` 字段 | ✅ 已定义 (UsrLinuxEmu 2026-05-08) | S3.5 同步点已完成 |
+| `gpu_device_info` 增加 warp_size 等字段 | ✅ 已完成 (2026-05-13) | struct 扩展到 144 字节，11 个新字段 |
+| Issue #13: Teardown SIGSEGV 修复 | ✅ 已修复 (2026-05-09, commit dd81e5c) | plugin_fini 销毁顺序修复 |
 
 ### 6.2 Phase 2 (待 S5 同步)
 
@@ -252,9 +269,9 @@ build/plugins/gpu_driver/
 | Phase 0 | 7 | 5 | 2 |
 | Phase 1 (定义) | 6 | 6 | 0 |
 | Phase 1 (实现) | 6 | 6 | 0 |
-| Phase 1.5 | 2 | 0 | 2 |
+| Phase 1.5 | 3 | 2 | 1 |
 | Phase 2 | 5 | 0 | 5 |
-| **总计** | **26** | **17** | **9** |
+| **总计** | **27** | **19** | **8** |
 
 ---
 


### PR DESCRIPTION
## Summary
- **fix(repo)**: 修复 `UsrLinuxEmu` 符号链接断裂 bug（main + H-1 分支都受影响）
- **docs**: AGENTS.md 标记 Issue #13 teardown SIGSEGV 已修复
- **feat(client)**: H-1 closeout — `setCurrentVASpace()` + 自动透传到 `submit_batch()`

## Commits (3)
1. `95136a5` fix(repo): repair UsrLinuxEmu symlink target
2. `2ce7806` docs: mark Issue #13 teardown SIGSEGV as fixed
3. `134fe0d` feat(client): plumb va_space_handle through GpuDriverClient (H-1 closeout)

## Test Evidence
- `test_cuda_scheduler`: **8 test cases / 8 passed / 0 failed · 50 assertions / 50 passed / 0 failed · SUCCESS**
- Build: `make -j4` exit 0
- Rebase: 0 conflicts (hunk 位置隔离，sync-plan.md §3.4 vs §3.5 物理分离)

## ABI Compatibility
- 默认 `current_va_space_handle_ = 0` → 走 H-1 sentinel 跳过校验
- 旧调用方零行为变化；新调用方 opt-in 启用 H-1 校验

## UsrLinuxEmu 侧 H-1 依赖
- [x] `0272970` gpu_pushbuffer_args 增加 va_space_handle
- [x] `bf8192f` PUSHBUFFER_SUBMIT_BATCH handler 加校验
- [x] `09ae1b0` test_gpu_pushbuffer_validation (4 cases)
- [x] `028d50a` 跨仓库同步
- [x] `f223994` 归档

Refs: TaskRunner AGENTS.md · UsrLinuxEmu change `h1-pushbuffer-validation-closeout`